### PR TITLE
Add support for timeboard_id from new datadog_dashboard block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,8 @@ locals {
 
   full_message = <<EOF
 ${var.message}
-${var.timeboard_id != "" ? "Timeboard: https://app.datadoghq.com/dash/${var.timeboard_id}" : ""}
+${var.dashboard_id != "" ? "Timeboard: https://app.datadoghq.com/dashboard/${var.dashboard_id}" : ""}
+${var.dashboard_id == "" && var.timeboard_id != "" ? "Timeboard: https://app.datadoghq.com/dash/${var.timeboard_id}" : ""}
 Related timeboards: https://app.datadoghq.com/dashboard/lists?q=${join("+-+", list(var.product_domain, var.service, var.environment))}
 Related monitors: https://app.datadoghq.com/monitors/manage?q=tag%3A%28%22${join("%22%20AND%20%22", local.tags)}%22%29
 Notification recipients:${local.recipients_message}${local.alert_message}${local.alert_recovery_message}${local.warning_message}${local.warning_recovery_message}

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
 
   full_message = <<EOF
 ${var.message}
-${var.dashboard_id != "" ? "Timeboard: https://app.datadoghq.com/dashboard/${var.dashboard_id}" : ""}
+${var.dashboard_id != "" ? "Dashboard: https://app.datadoghq.com/dashboard/${var.dashboard_id}" : ""}
 ${var.dashboard_id == "" && var.timeboard_id != "" ? "Timeboard: https://app.datadoghq.com/dash/${var.timeboard_id}" : ""}
 Related timeboards: https://app.datadoghq.com/dashboard/lists?q=${join("+-+", list(var.product_domain, var.service, var.environment))}
 Related monitors: https://app.datadoghq.com/monitors/manage?q=tag%3A%28%22${join("%22%20AND%20%22", local.tags)}%22%29

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "timeboard_id" {
 variable "dashboard_id" {
   type        = "string"
   default     = ""
-  description = "The timeboard_id if you are using new datadog_dashboard block"
+  description = "The dashboard id for this monitor (if you are using new datadog_dashboard block)"
 }
 
 variable "recipients" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "timeboard_id" {
   description = "The timeboard id for this monitor"
 }
 
+variable "dashboard_id" {
+  type        = "string"
+  default     = ""
+  description = "The timeboard_id if you are using new datadog_dashboard block"
+}
+
 variable "recipients" {
   type        = "list"
   default     = []


### PR DESCRIPTION
## Summary
Based on [this doc](https://www.terraform.io/docs/providers/datadog/r/timeboard.html) the `datadog_timeboard` block is outdated and recommended to use the new block `datadog_dashboard`

However, the `id` returns by `datadog_timeboard` and `datadog_dashboard` is different. 

This PR will accommodate that issue by introducing var `dashboard_id` 

## Test Plan
Clone the module to local, modify and test.
Created monitor in `tvlk-prod` https://app.datadoghq.com/monitors/16040997