### PR TITLE
Add support to require_full_window in datadog_monitor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,5 +34,7 @@ resource "datadog_monitor" "template" {
   notify_audit      = "${var.notify_audit}"
   include_tags      = "${var.include_tags}"
 
+  require_full_window = "${var.require_full_window}"
+
   tags = "${concat(local.tags, var.tags)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,6 @@ variable "include_tags" {
 
 variable "require_full_window" {
   type        = "string"
-  default     = false
+  default     = true
   description = "Whether require full window of data for evaluation"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,9 @@ variable "include_tags" {
   default     = true
   description = "Whether to include tags in name"
 }
+
+variable "require_full_window" {
+  type        = "string"
+  default     = false
+  description = "Whether require full window of data for evaluation"
+}


### PR DESCRIPTION
# Summary
Sometimes, we need to change the value for `require_full_window` from `true` to `false` when the metric is sparse, therefore the monitor will be evaluated even though there's no data retrieved by Datadog.

## Resource:
- https://www.terraform.io/docs/providers/datadog/r/monitor.html#require_full_window
- https://docs.datadoghq.com/monitors/monitor_types/metric/?tab=threshold#data-window

# Test Plan
- Cloning the module and test it locally
- Will send the created monitor if needed